### PR TITLE
Use SKIP LOCKED to speed up lookups where using large numbers of workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ https://groups.google.com/d/forum/queue_classic
 ### Dependencies
 
 * Ruby 1.9.2
-* Postgres ~> 9.0
+* Postgres ~> 9.5
 * Rubygem: pg ~> 0.11.0
 * For JRuby, see [queue_classic_java](https://github.com/bdon/queue_classic_java)
 

--- a/lib/queue_classic.rb
+++ b/lib/queue_classic.rb
@@ -12,7 +12,6 @@ module QC
     :TABLE_NAME => :table_name,
     :QUEUE => :queue,
     :QUEUES => :queues,
-    :TOP_BOUND => :top_bound,
     :FORK_WORKER => :fork_worker?,
   }
 

--- a/lib/queue_classic/config.rb
+++ b/lib/queue_classic/config.rb
@@ -41,12 +41,6 @@ module QC
       @queues ||= (ENV["QUEUES"] && ENV["QUEUES"].split(",").map(&:strip)) || []
     end
 
-    # Set this to 1 for strict FIFO.
-    # There is nothing special about 9....
-    def top_bound
-      @top_bound ||= (ENV["QC_TOP_BOUND"] || 9).to_i
-    end
-
     # Set this variable if you wish for
     # the worker to fork a UNIX process for
     # each locked job. Remember to re-establish

--- a/lib/queue_classic/queue.rb
+++ b/lib/queue_classic/queue.rb
@@ -6,10 +6,9 @@ module QC
   # The queue class maps a queue abstraction onto a database table.
   class Queue
 
-    attr_reader :name, :top_bound
-    def initialize(name, top_bound=nil)
+    attr_reader :name
+    def initialize(name)
       @name = name
-      @top_bound = top_bound || QC.top_bound
     end
 
     def conn_adapter=(a)
@@ -70,8 +69,8 @@ module QC
 
     def lock
       QC.log_yield(:measure => 'queue.lock') do
-        s = "SELECT * FROM lock_head($1, $2)"
-        if r = conn_adapter.execute(s, name, top_bound)
+        s = "SELECT * FROM lock_head($1)"
+        if r = conn_adapter.execute(s, name)
           {}.tap do |job|
             job[:id] = r["id"]
             job[:q_name] = r["q_name"]

--- a/lib/queue_classic/worker.rb
+++ b/lib/queue_classic/worker.rb
@@ -15,7 +15,6 @@ module QC
     # connection:: PG::Connection object.
     # q_name:: Name of a single queue to process.
     # q_names:: Names of queues to process. Will process left to right.
-    # top_bound:: Offset to the head of the queue. 1 == strict FIFO.
     def initialize(args={})
       @fork_worker = args[:fork_worker] || QC.fork_worker?
       @wait_interval = args[:wait_interval] || QC.wait_time
@@ -28,8 +27,7 @@ module QC
 
       @queues = setup_queues(@conn_adapter,
         (args[:q_name] || QC.queue),
-        (args[:q_names] || QC.queues),
-        (args[:top_bound] || QC.top_bound))
+        (args[:q_names] || QC.queues))
       log(args.merge(:at => "worker_initialized"))
       @running = true
     end
@@ -153,10 +151,10 @@ module QC
 
     private
 
-    def setup_queues(adapter, queue, queues, top_bound)
+    def setup_queues(adapter, queue, queues)
       names = queues.length > 0 ? queues : [queue]
       names.map do |name|
-        QC::Queue.new(name, top_bound).tap do |q|
+        QC::Queue.new(name).tap do |q|
           q.conn_adapter = adapter
         end
       end

--- a/sql/ddl.sql
+++ b/sql/ddl.sql
@@ -3,70 +3,20 @@
 -- have identical columns to queue_classic_jobs.
 -- When QC supports queues with columns other than the default, we will have to change this.
 
-CREATE OR REPLACE FUNCTION lock_head(q_name varchar, top_boundary integer)
+CREATE OR REPLACE FUNCTION lock_head(queue_name varchar)
 RETURNS SETOF queue_classic_jobs AS $$
-DECLARE
-  unlocked bigint;
-  relative_top integer;
-  job_count integer;
 BEGIN
-  -- The purpose is to release contention for the first spot in the table.
-  -- The select count(*) is going to slow down dequeue performance but allow
-  -- for more workers. Would love to see some optimization here...
-
-  EXECUTE 'SELECT count(*) FROM '
-    || '(SELECT * FROM queue_classic_jobs '
-    || ' WHERE locked_at IS NULL'
-    || ' AND q_name = '
-    || quote_literal(q_name)
-    || ' AND scheduled_at <= '
-    || quote_literal(now())
-    || ' LIMIT '
-    || quote_literal(top_boundary)
-    || ') limited'
-  INTO job_count;
-
-  SELECT TRUNC(random() * (top_boundary - 1))
-  INTO relative_top;
-
-  IF job_count < top_boundary THEN
-    relative_top = 0;
-  END IF;
-
-  LOOP
-    BEGIN
-      EXECUTE 'SELECT id FROM queue_classic_jobs '
-        || ' WHERE locked_at IS NULL'
-        || ' AND q_name = '
-        || quote_literal(q_name)
-        || ' AND scheduled_at <= '
-        || quote_literal(now())
-        || ' ORDER BY id ASC'
-        || ' LIMIT 1'
-        || ' OFFSET ' || quote_literal(relative_top)
-        || ' FOR UPDATE NOWAIT'
-      INTO unlocked;
-      EXIT;
-    EXCEPTION
-      WHEN lock_not_available THEN
-        -- do nothing. loop again and hope we get a lock
-    END;
-  END LOOP;
-
   RETURN QUERY EXECUTE 'UPDATE queue_classic_jobs '
-    || ' SET locked_at = (CURRENT_TIMESTAMP),'
-    || ' locked_by = (select pg_backend_pid())'
-    || ' WHERE id = $1'
-    || ' AND locked_at is NULL'
-    || ' RETURNING *'
-  USING unlocked;
-
-  RETURN;
-END $$ LANGUAGE plpgsql;
-
-CREATE OR REPLACE FUNCTION lock_head(tname varchar) RETURNS SETOF queue_classic_jobs AS $$ BEGIN
-  RETURN QUERY EXECUTE 'SELECT * FROM lock_head($1,10)' USING tname;
-END $$ LANGUAGE plpgsql;
+    || 'SET locked_at = now(), '
+    || 'locked_by = pg_backend_pid() '
+    || 'WHERE id IN ( '
+      || 'SELECT id FROM queue_classic_jobs '
+      || 'WHERE locked_at IS NULL AND q_name = $1 AND  scheduled_at <= now() '
+      || 'LIMIT 1 '
+      || 'FOR NO KEY UPDATE SKIP LOCKED '
+    || ') RETURNING *;' USING queue_name;
+END
+$$ LANGUAGE plpgsql;
 
 -- queue_classic_notify function and trigger
 CREATE FUNCTION queue_classic_notify() RETURNS TRIGGER AS $$ BEGIN

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -67,16 +67,6 @@ class ConfigTest < QCTest
     end
   end
 
-  def test_top_bound_default
-    assert_equal 9, QC.top_bound
-  end
-
-  def test_configure_top_bound_with_env_var
-    with_env "QC_TOP_BOUND" => "5" do
-      assert_equal 5, QC.top_bound
-    end
-  end
-
   def test_fork_worker_default
     refute QC.fork_worker?
   end


### PR DESCRIPTION
Thanks to research by @MSch done here:
https://github.com/QueueClassic/queue_classic/issues/279

- [x] Test in a heavy performance scenario
- [ ] Create PR into QueueClassic/queue_classic

